### PR TITLE
Revert removal of show cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "term.js-cockpit",
   "description": "Cockpit's fork of the term.js project",
   "author": "Christopher Jeffrey",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "main": "./index.js",
   "preferGlobal": false,

--- a/src/term.js
+++ b/src/term.js
@@ -1332,6 +1332,11 @@ Terminal.prototype.refresh = function(start, end) {
   }
 };
 
+Terminal.prototype.showCursor = function() {
+  this.cursorHidden = false;
+  this.refresh(this.y, this.y);
+};
+
 Terminal.prototype.scroll = function() {
   var row;
 


### PR DESCRIPTION
This was an API break and kubernetes-container-terminal was using it.

Also bump the version.