### PR TITLE
New option added: disableScrollingRegion

### DIFF
--- a/src/term.js
+++ b/src/term.js
@@ -441,6 +441,7 @@ Terminal.defaults = {
   popOnBell: false,
   scrollback: 1000,
   screenKeys: false,
+  disableScrollingRegion: false,
   debug: false,
   // programFeatures: false,
   // focusKeys: false,
@@ -2019,7 +2020,9 @@ Terminal.prototype.write = function(data) {
           //   dow) (DECSTBM).
           // CSI ? Pm r
           case 'r':
-            this.setScrollRegion(this.params);
+            if (!this.disableScrollingRegion) {
+              this.setScrollRegion(this.params);
+            } 
             break;
 
           // CSI s


### PR DESCRIPTION
New `disableScrollingRegion` option is added to
the Terminal constructor.

When set to `true`, the Control Sequence Introducer `r`
is ignored.

Useful when Terminal is connected to a serial console
of a virtual machine which is being restarted. In that
case, the `CSI r` is received with incorrect value
causing Terminal to fail.

When the option is not explicitely set, behavior
remains same.